### PR TITLE
Support 16 configurable colors in text reports

### DIFF
--- a/webchanges/storage.py
+++ b/webchanges/storage.py
@@ -56,6 +56,16 @@ DEFAULT_CONFIG = {
             'footer': True,
             'minimal': False,
         },
+        'colors': {
+            'add': 'green',
+            'delete': 'red',
+            'context': 'default',
+            'separator': 'default',
+            'status_new': 'lightgreen',
+            'status_changed': 'lightblue',
+            'status_unchanged': 'darkgray',
+            'status_error': 'lightred',
+        },
         # the keys below control where a report is displayed and/or sent
         'stdout': {  # the console / command line display
             'enabled': True,


### PR DESCRIPTION
Changes:

* Support 16 colors in text reports
* Distinguish more report parts by color (e.g. separators, context)
* Add configuration options for colors by name

To do:

* Documentation
* Tests

Let me know if you are interested in these changes and if you have any ideas, feedback, requests…