### PR TITLE
Bugfix: Write value of argument "--config" to attribute "config_file"

### DIFF
--- a/webchanges/config.py
+++ b/webchanges/config.py
@@ -120,10 +120,20 @@ class CommandConfig(BaseConfig):
             dest='jobs_def_file',
         )
         group.add_argument(
-            '--config', default=self.config_file, type=Path, help='read configuration from FILE', metavar='FILE'
+            '--config',
+            default=self.config_file,
+            type=Path,
+            help='read configuration from FILE',
+            metavar='FILE',
+            dest='config_file',
         )
         group.add_argument(
-            '--hooks', default=self.hooks_file, type=Path, help='use FILE as imported hooks.py module', metavar='FILE'
+            '--hooks',
+            default=self.hooks_file,
+            type=Path,
+            help='use FILE as imported hooks.py module',
+            metavar='FILE',
+            dest='hooks_file',
         )
         group.add_argument(
             '--cache',


### PR DESCRIPTION
Without this change the value of the argument "--config" given on the command line is ignored completely, but a new default config file gets created. With this change the config file specified on the command line is used correctly.

As far as I can see in the code the same seems to apply to the command line argument "--hooks" and the attribute "hooks_file".