### PR TITLE
build: Exclude tests from being recognized as package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ SETUP = {
     'author': re.match(r'(.*) <(.*)>', project.__author__).groups()[0],  # type: ignore[union-attr]
     'author_email': re.match(r'(.*) <(.*)>', project.__author__).groups()[1],  # type: ignore[union-attr]
     'url': project.__url__,
-    'packages': find_packages(),
+    'packages': find_packages(exclude=["tests"]),
     'classifiers': [
         'Environment :: Console',
         'Topic :: Internet',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ SETUP = {
     'author': re.match(r'(.*) <(.*)>', project.__author__).groups()[0],  # type: ignore[union-attr]
     'author_email': re.match(r'(.*) <(.*)>', project.__author__).groups()[1],  # type: ignore[union-attr]
     'url': project.__url__,
-    'packages': find_packages(exclude=["tests"]),
+    'packages': find_packages(exclude=['tests']),
     'classifiers': [
         'Environment :: Console',
         'Topic :: Internet',


### PR DESCRIPTION
See https://github.com/simonw/csv-diff/pull/32 and https://aur.archlinux.org/packages/webchanges#comment-896122

TLDR: Exclude the tests from being packaged.