### PR TITLE
Set date in sent emails

### DIFF
--- a/webchanges/mailer.py
+++ b/webchanges/mailer.py
@@ -9,7 +9,7 @@ import logging
 import smtplib
 import subprocess  # noqa: S404 Consider possible security implications associated with the subprocess module.
 from dataclasses import dataclass
-from email import policy
+from email import policy, utils
 from email.message import EmailMessage
 from pathlib import Path
 from types import ModuleType
@@ -50,6 +50,7 @@ class Mailer:
         msg['From'] = from_email
         msg['To'] = to_email
         msg['Subject'] = subject
+        msg['Date'] = utils.formatdate(localtime=True)
         msg.set_content(text_body, subtype='plain')
         if html_body is not None:
             msg.add_alternative(html_body, subtype='html')


### PR DESCRIPTION
E-Mails sent by `webchanges` lack the `Date` field and, hence, gets some date assigned by the receiving client. This has the consequence that, when e.g., my phone was turned off, and `webchanges` sent emails, they all arrive in the same second once the phone is back online.

This can be reproduced reliably by setting a client into airplane/offline mode for some time while messages are being sent. Note: Some mail servers may add the Date field if they see it is missing, however, many don't.